### PR TITLE
docs: update GH action and node versions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION

## **Description:**

- Updated GitHub Actions in the [README](https://github.com/junobuild/juno-action/blob/main/README.md):
  - Bumped `actions/checkout@v3` to `actions/checkout@v4`.
  - Bumped `actions/setup-node@v3` to `actions/setup-node@v4`.
- Updated Node version in the [README](https://github.com/junobuild/juno-action/blob/main/README.md) from 18 to 20.

Resolves #3 
