### PR TITLE
feat: remove JUNO_TOKEN assertion

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if [ -z "$JUNO_TOKEN" ]; then
-  echo "A JUNO_TOKEN is required to run commands with the Juno cli"
-  exit 126
-fi
-
 if [ -n "$PROJECT_PATH" ]; then
   cd "$PROJECT_PATH"
 fi


### PR DESCRIPTION
Commands like "Juno dev build" do not need a token