### PR TITLE
build: bump cli v0.9.4 and Juno main v0.0.57

### DIFF
--- a/.github/workflows/test-cli.yaml
+++ b/.github/workflows/test-cli.yaml
@@ -34,8 +34,8 @@ jobs:
         run: |
           OUTPUT=$(docker run --rm -e JUNO_TOKEN="${{ secrets.JUNO_TOKEN }}" juno-action:test-${{ matrix.dockerfile == 'Dockerfile.full' && 'full' || 'slim' }} version --cli)
           echo "$OUTPUT"
-          if [[ "$OUTPUT" != *"v0.9.3"* ]]; then
-            echo "❌ Expected version v0.9.3 not found in output"
+          if [[ "$OUTPUT" != *"v0.9.4"* ]]; then
+            echo "❌ Expected version v0.9.4 not found in output"
             exit 1
           fi
         shell: bash

--- a/kit/setup/tools
+++ b/kit/setup/tools
@@ -2,6 +2,6 @@
 
 set -e
 
-npm i -g @junobuild/cli@0.9.3
+npm i -g @junobuild/cli@0.9.4
 
 npm i -g pnpm@10.17.0


### PR DESCRIPTION
Bump for Juno release [v0.0.57](https://github.com/junobuild/juno/releases/tag/v0.0.57)