### PR TITLE
feat: pre-build Cargo dependencies to speed up serverless function compilation

### DIFF
--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -109,7 +109,7 @@ COPY --from=builder --chown=apprunner:apprunner /juno/target/juno-main/rust-tool
 # Copy pre-built Cargo dependencies to avoid recompiling them on each CI run
 # Particularly useful for Sputnik since its version is always the one bundled
 # in the image
-COPY --from=builder --chown=apprunner:apprunner /juno/target/juno-main/target /juno/target
+COPY --from=builder --chown=apprunner:apprunner /juno/target /juno/target
 COPY --from=builder --chown=apprunner:apprunner /home/apprunner/.cargo/registry /home/apprunner/.cargo/registry
 
 # Resolves cargo build error:

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -8,6 +8,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
     bash \
     curl \
     build-essential \
+    jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a working user
@@ -43,6 +44,24 @@ COPY --chown=apprunner:apprunner ./kit/setup/bootstrap ./kit/setup/bootstrap
 
 # Install core tools required for building WASM (same as in the main Juno repository)
 RUN ./kit/setup/bootstrap
+
+# Pre-build all cargo dependencies for Sputnik build
+RUN cd /juno/target/juno-main \
+    && mkdir -p src/satellite/src && touch src/satellite/src/lib.rs \
+    && mkdir -p src/sputnik/src && touch src/sputnik/src/lib.rs \
+    && mkdir -p src/libs/macros/src && touch src/libs/macros/src/lib.rs \
+    && mkdir -p src/libs/satellite/src && touch src/libs/satellite/src/lib.rs \
+    && mkdir -p src/libs/shared/src && touch src/libs/shared/src/lib.rs \
+    && mkdir -p src/libs/utils/src && touch src/libs/utils/src/lib.rs \
+    && mkdir -p src/libs/collections/src && touch src/libs/collections/src/lib.rs \
+    && mkdir -p src/libs/storage/src && touch src/libs/storage/src/lib.rs \
+    && mkdir -p src/libs/cdn/src && touch src/libs/cdn/src/lib.rs \
+    && mkdir -p src/libs/auth/src && touch src/libs/auth/src/lib.rs \
+    && ./docker/build-deps
+
+# Pre-build latest junobuild-* cargo dependencies for Satellites functions build
+COPY --chown=apprunner:apprunner ./kit/deps /home/apprunner/deps
+RUN cd /home/apprunner/deps && cargo build --target wasm32-unknown-unknown --release
 
 # --- Runtime Stage ---
 FROM node:24-slim@sha256:76d0ed0ed93bed4f4376211e9d8fddac4d8b3fbdb54cc45955696001a3c91152
@@ -99,6 +118,12 @@ COPY --from=builder --chown=apprunner:apprunner /juno/target/juno-main/src /juno
 COPY --from=builder --chown=apprunner:apprunner /juno/target/juno-main/Cargo.lock /juno/Cargo.lock
 COPY --from=builder --chown=apprunner:apprunner /juno/target/juno-main/Cargo.toml /juno/Cargo.toml
 COPY --from=builder --chown=apprunner:apprunner /juno/target/juno-main/rust-toolchain.toml /juno/rust-toolchain.toml
+
+# Copy pre-built Cargo dependencies to avoid recompiling them on each CI run
+# Particularly useful for Sputnik since its version is always the one bundled
+# in the image
+COPY --from=builder --chown=apprunner:apprunner /juno/target/juno-main/target /juno/target
+COPY --from=builder --chown=apprunner:apprunner /home/apprunner/.cargo/registry /home/apprunner/.cargo/registry
 
 # Resolves cargo build error:
 # network failure seems to have happened

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -61,7 +61,7 @@ RUN cd /juno/target/juno-main \
 
 # Pre-build latest junobuild-* cargo dependencies for Satellites functions build
 COPY --chown=apprunner:apprunner ./kit/deps /home/apprunner/deps
-RUN cd /home/apprunner/deps && cargo build --target wasm32-unknown-unknown --release
+RUN cd /home/apprunner/deps && cargo build --target wasm32-unknown-unknown --target-dir /juno/target/juno-main/target --release
 
 # --- Runtime Stage ---
 FROM node:24-slim@sha256:76d0ed0ed93bed4f4376211e9d8fddac4d8b3fbdb54cc45955696001a3c91152

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -45,23 +45,10 @@ COPY --chown=apprunner:apprunner ./kit/setup/bootstrap ./kit/setup/bootstrap
 # Install core tools required for building WASM (same as in the main Juno repository)
 RUN ./kit/setup/bootstrap
 
-# Pre-build all cargo dependencies for Sputnik build
-RUN cd /juno/target/juno-main \
-    && mkdir -p src/satellite/src && touch src/satellite/src/lib.rs \
-    && mkdir -p src/sputnik/src && touch src/sputnik/src/lib.rs \
-    && mkdir -p src/libs/macros/src && touch src/libs/macros/src/lib.rs \
-    && mkdir -p src/libs/satellite/src && touch src/libs/satellite/src/lib.rs \
-    && mkdir -p src/libs/shared/src && touch src/libs/shared/src/lib.rs \
-    && mkdir -p src/libs/utils/src && touch src/libs/utils/src/lib.rs \
-    && mkdir -p src/libs/collections/src && touch src/libs/collections/src/lib.rs \
-    && mkdir -p src/libs/storage/src && touch src/libs/storage/src/lib.rs \
-    && mkdir -p src/libs/cdn/src && touch src/libs/cdn/src/lib.rs \
-    && mkdir -p src/libs/auth/src && touch src/libs/auth/src/lib.rs \
-    && ./docker/build-deps
-
-# Pre-build latest junobuild-* cargo dependencies for Satellites functions build
+# Pre-build Cargo dependencies to speed up serverless function compilation when used in the actions
 COPY --chown=apprunner:apprunner ./kit/deps /home/apprunner/deps
-RUN cd /home/apprunner/deps && cargo build --target wasm32-unknown-unknown --target-dir /juno/target/juno-main/target --release
+COPY --chown=apprunner:apprunner ./kit/setup/prebuild ./kit/setup/prebuild
+RUN ./kit/setup/prebuild
 
 # --- Runtime Stage ---
 FROM node:24-slim@sha256:76d0ed0ed93bed4f4376211e9d8fddac4d8b3fbdb54cc45955696001a3c91152

--- a/docker/download/init
+++ b/docker/download/init
@@ -3,3 +3,7 @@
 set -euo pipefail
 
 ./docker/download/juno-source
+
+# Remove [patch.crates-io] section so developer satellite builds resolve
+# their declared junobuild-* versions from crates.io instead of the bundled workspace
+sed -i '/^\[patch\.crates-io\]/,/^$/d' "$JUNO_MAIN_DIR/Cargo.toml"

--- a/docker/download/init
+++ b/docker/download/init
@@ -3,7 +3,3 @@
 set -euo pipefail
 
 ./docker/download/juno-source
-
-# Remove [patch.crates-io] section so developer satellite builds resolve
-# their declared junobuild-* versions from crates.io instead of the bundled workspace
-sed -i '/^\[patch\.crates-io\]/,/^$/d' "$JUNO_MAIN_DIR/Cargo.toml"

--- a/kit/deps/Cargo.toml
+++ b/kit/deps/Cargo.toml
@@ -8,11 +8,15 @@ edition = "2021"
 [lib]
 
 [dependencies]
-junobuild-satellite = { version = "*", default-features = false }
-junobuild-macros = "*"
-junobuild-utils = "*"
-junobuild-shared = "*"
-junobuild-collections = "*"
-junobuild-storage = "*"
-junobuild-cdn = "*"
-junobuild-auth = "*"
+candid = "0.10.20"
+ic-cdk = "0.19.0"
+ic-cdk-macros = "0.19.0"
+serde = "1.0.225"
+junobuild-satellite = { version = "0.6.0", default-features = false }
+junobuild-macros = "0.4.0"
+junobuild-utils = "0.4.0"
+junobuild-shared = "0.8.0"
+junobuild-collections = "0.5.0"
+junobuild-storage = "0.7.0"
+junobuild-cdn = "0.7.0"
+junobuild-auth = "0.4.0"

--- a/kit/deps/Cargo.toml
+++ b/kit/deps/Cargo.toml
@@ -1,5 +1,5 @@
-# Dummy crate to pre-build the latest published junobuild-* dependencies into the
-# Cargo target cache, so developers don't have to compile them from scratch on each CI run.
+# Dummy crate to pre-download and build the latest published junobuild-* dependencies into the
+# Cargo target cache, so developers don't have to download them on each CI run.
 [package]
 name = "deps"
 version = "0.0.1"

--- a/kit/deps/Cargo.toml
+++ b/kit/deps/Cargo.toml
@@ -1,0 +1,18 @@
+# Dummy crate to pre-build the latest published junobuild-* dependencies into the
+# Cargo target cache, so developers don't have to compile them from scratch on each CI run.
+[package]
+name = "deps"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+
+[dependencies]
+junobuild-satellite = { version = "*", default-features = false }
+junobuild-macros = "*"
+junobuild-utils = "*"
+junobuild-shared = "*"
+junobuild-collections = "*"
+junobuild-storage = "*"
+junobuild-cdn = "*"
+junobuild-auth = "*"

--- a/kit/deps/src/lib.rs
+++ b/kit/deps/src/lib.rs
@@ -1,0 +1,3 @@
+use junobuild_macros::include_satellite;
+
+include_satellite!();

--- a/kit/deps/src/lib.rs
+++ b/kit/deps/src/lib.rs
@@ -1,3 +1,3 @@
-use junobuild_macros::include_satellite;
+use junobuild_satellite::include_satellite;
 
 include_satellite!();

--- a/kit/setup/prebuild
+++ b/kit/setup/prebuild
@@ -3,21 +3,19 @@
 set -euo pipefail
 
 # Pre-build all cargo dependencies for Sputnik build
-mkdir -p "$JUNO_MAIN_DIR/src/satellite/src" && touch "$JUNO_MAIN_DIR/src/satellite/src/lib.rs"
-mkdir -p "$JUNO_MAIN_DIR/src/sputnik/src" && touch "$JUNO_MAIN_DIR/src/sputnik/src/lib.rs"
-mkdir -p "$JUNO_MAIN_DIR/src/libs/macros/src" && touch "$JUNO_MAIN_DIR/src/libs/macros/src/lib.rs"
-mkdir -p "$JUNO_MAIN_DIR/src/libs/satellite/src" && touch "$JUNO_MAIN_DIR/src/libs/satellite/src/lib.rs"
-mkdir -p "$JUNO_MAIN_DIR/src/libs/shared/src" && touch "$JUNO_MAIN_DIR/src/libs/shared/src/lib.rs"
-mkdir -p "$JUNO_MAIN_DIR/src/libs/utils/src" && touch "$JUNO_MAIN_DIR/src/libs/utils/src/lib.rs"
-mkdir -p "$JUNO_MAIN_DIR/src/libs/collections/src" && touch "$JUNO_MAIN_DIR/src/libs/collections/src/lib.rs"
-mkdir -p "$JUNO_MAIN_DIR/src/libs/storage/src" && touch "$JUNO_MAIN_DIR/src/libs/storage/src/lib.rs"
-mkdir -p "$JUNO_MAIN_DIR/src/libs/cdn/src" && touch "$JUNO_MAIN_DIR/src/libs/cdn/src/lib.rs"
-mkdir -p "$JUNO_MAIN_DIR/src/libs/auth/src" && touch "$JUNO_MAIN_DIR/src/libs/auth/src/lib.rs"
-"$JUNO_MAIN_DIR/docker/build-deps"
+cd "$JUNO_MAIN_DIR" \
+    && mkdir -p src/satellite/src && touch src/satellite/src/lib.rs \
+    && mkdir -p src/sputnik/src && touch src/sputnik/src/lib.rs \
+    && mkdir -p src/libs/macros/src && touch src/libs/macros/src/lib.rs \
+    && mkdir -p src/libs/satellite/src && touch src/libs/satellite/src/lib.rs \
+    && mkdir -p src/libs/shared/src && touch src/libs/shared/src/lib.rs \
+    && mkdir -p src/libs/utils/src && touch src/libs/utils/src/lib.rs \
+    && mkdir -p src/libs/collections/src && touch src/libs/collections/src/lib.rs \
+    && mkdir -p src/libs/storage/src && touch src/libs/storage/src/lib.rs \
+    && mkdir -p src/libs/cdn/src && touch src/libs/cdn/src/lib.rs \
+    && mkdir -p src/libs/auth/src && touch src/libs/auth/src/lib.rs \
+    && ./docker/build-deps
 
-# Pre-build latest junobuild-* cargo dependencies for Satellites functions build
-RUSTFLAGS='--cfg getrandom_backend="custom"' cargo build \
-    --manifest-path /home/apprunner/deps/Cargo.toml \
-    --target wasm32-unknown-unknown \
-    --target-dir "$JUNO_MAIN_DIR/target" \
-    --release
+# Pre-build latest published junobuild-* dependencies for satellite builds
+cd /home/apprunner/deps
+RUSTFLAGS='--cfg getrandom_backend="custom"' cargo build --target wasm32-unknown-unknown --target-dir "$JUNO_MAIN_DIR/target" --release

--- a/kit/setup/prebuild
+++ b/kit/setup/prebuild
@@ -14,7 +14,8 @@ cd "$JUNO_MAIN_DIR" \
     && mkdir -p src/libs/storage/src && touch src/libs/storage/src/lib.rs \
     && mkdir -p src/libs/cdn/src && touch src/libs/cdn/src/lib.rs \
     && mkdir -p src/libs/auth/src && touch src/libs/auth/src/lib.rs \
-    && ./docker/build-deps
+    && ./docker/build --only-dependencies --satellite \
+    && ./docker/build --only-dependencies --sputnik
 
 # Pre-build latest published junobuild-* dependencies for satellite builds
 cd /home/apprunner/deps

--- a/kit/setup/prebuild
+++ b/kit/setup/prebuild
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Pre-build all cargo dependencies for Sputnik build
+mkdir -p "$JUNO_MAIN_DIR/src/satellite/src" && touch "$JUNO_MAIN_DIR/src/satellite/src/lib.rs"
+mkdir -p "$JUNO_MAIN_DIR/src/sputnik/src" && touch "$JUNO_MAIN_DIR/src/sputnik/src/lib.rs"
+mkdir -p "$JUNO_MAIN_DIR/src/libs/macros/src" && touch "$JUNO_MAIN_DIR/src/libs/macros/src/lib.rs"
+mkdir -p "$JUNO_MAIN_DIR/src/libs/satellite/src" && touch "$JUNO_MAIN_DIR/src/libs/satellite/src/lib.rs"
+mkdir -p "$JUNO_MAIN_DIR/src/libs/shared/src" && touch "$JUNO_MAIN_DIR/src/libs/shared/src/lib.rs"
+mkdir -p "$JUNO_MAIN_DIR/src/libs/utils/src" && touch "$JUNO_MAIN_DIR/src/libs/utils/src/lib.rs"
+mkdir -p "$JUNO_MAIN_DIR/src/libs/collections/src" && touch "$JUNO_MAIN_DIR/src/libs/collections/src/lib.rs"
+mkdir -p "$JUNO_MAIN_DIR/src/libs/storage/src" && touch "$JUNO_MAIN_DIR/src/libs/storage/src/lib.rs"
+mkdir -p "$JUNO_MAIN_DIR/src/libs/cdn/src" && touch "$JUNO_MAIN_DIR/src/libs/cdn/src/lib.rs"
+mkdir -p "$JUNO_MAIN_DIR/src/libs/auth/src" && touch "$JUNO_MAIN_DIR/src/libs/auth/src/lib.rs"
+"$JUNO_MAIN_DIR/docker/build-deps"
+
+# Pre-build latest junobuild-* cargo dependencies for Satellites functions build
+RUSTFLAGS='--cfg getrandom_backend="custom"' cargo build \
+    --manifest-path /home/apprunner/deps/Cargo.toml \
+    --target wasm32-unknown-unknown \
+    --target-dir "$JUNO_MAIN_DIR/target" \
+    --release

--- a/kit/setup/prebuild
+++ b/kit/setup/prebuild
@@ -14,9 +14,11 @@ cd "$JUNO_MAIN_DIR" \
     && mkdir -p src/libs/storage/src && touch src/libs/storage/src/lib.rs \
     && mkdir -p src/libs/cdn/src && touch src/libs/cdn/src/lib.rs \
     && mkdir -p src/libs/auth/src && touch src/libs/auth/src/lib.rs \
-    && ./docker/build --only-dependencies --satellite \
     && ./docker/build --only-dependencies --sputnik
 
-# Pre-build latest published junobuild-* dependencies for satellite builds
+# Pre-download latest published junobuild-* dependencies into the Cargo registry cache.
+# Note: even though we compile them here, the artifacts won't be reused at runtime because
+# Cargo fingerprints are tied to the workspace - the developer's project is a different
+# workspace, so everything will recompile. Only the download step is saved.
 cd /home/apprunner/deps
 RUSTFLAGS='--cfg getrandom_backend="custom"' cargo build --target wasm32-unknown-unknown --target-dir "$JUNO_MAIN_DIR/target" --release

--- a/kit/setup/prebuild
+++ b/kit/setup/prebuild
@@ -20,5 +20,8 @@ cd "$JUNO_MAIN_DIR" \
 # Note: even though we compile them here, the artifacts won't be reused at runtime because
 # Cargo fingerprints are tied to the workspace - the developer's project is a different
 # workspace, so everything will recompile. Only the download step is saved.
+# TODO: with a third party tool like sscache we might be able to cache the artifacts
+# https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/cargo/guide/build-cache.html
+# https://github.com/mozilla/sccache
 cd /home/apprunner/deps
 RUSTFLAGS='--cfg getrandom_backend="custom"' cargo build --target wasm32-unknown-unknown --target-dir "$JUNO_MAIN_DIR/target" --release

--- a/kit/setup/prebuild
+++ b/kit/setup/prebuild
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+JUNO_TARGET_DIR=/juno/target
+
 # Pre-build all cargo dependencies for Sputnik build
 cd "$JUNO_MAIN_DIR" \
     && mkdir -p src/satellite/src && touch src/satellite/src/lib.rs \
@@ -14,7 +16,7 @@ cd "$JUNO_MAIN_DIR" \
     && mkdir -p src/libs/storage/src && touch src/libs/storage/src/lib.rs \
     && mkdir -p src/libs/cdn/src && touch src/libs/cdn/src/lib.rs \
     && mkdir -p src/libs/auth/src && touch src/libs/auth/src/lib.rs \
-    && ./docker/build --only-dependencies --sputnik
+    && CARGO_TARGET_DIR="$JUNO_TARGET_DIR" ./docker/build --only-dependencies --sputnik
 
 # Pre-download latest published junobuild-* dependencies into the Cargo registry cache.
 # Note: even though we compile them here, the artifacts won't be reused at runtime because
@@ -24,4 +26,4 @@ cd "$JUNO_MAIN_DIR" \
 # https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/cargo/guide/build-cache.html
 # https://github.com/mozilla/sccache
 cd /home/apprunner/deps
-RUSTFLAGS='--cfg getrandom_backend="custom"' cargo build --target wasm32-unknown-unknown --target-dir "$JUNO_MAIN_DIR/target" --release
+RUSTFLAGS='--cfg getrandom_backend="custom" -A deprecated' cargo build --target wasm32-unknown-unknown --target-dir "$JUNO_TARGET_DIR" --release


### PR DESCRIPTION
Developer CI builds should become significantly faster.

With this PR, building Serverless Functions in TypeScript won't require downloading and building Sputnik anymore.
For Rust functions, this PR will "only" helps not download the latest dependencies if the dev use those.