### PR TITLE
test: replace juno --version command

### DIFF
--- a/.github/workflows/test-cli.yaml
+++ b/.github/workflows/test-cli.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Test Juno CLI version
         run: |
-          OUTPUT=$(docker run --rm -e JUNO_TOKEN="${{ secrets.JUNO_TOKEN }}" juno-action:test-${{ matrix.dockerfile == 'Dockerfile.full' && 'full' || 'slim' }} version --cli)
+          OUTPUT=$(docker run --rm -e JUNO_TOKEN="${{ secrets.JUNO_TOKEN }}" juno-action:test-${{ matrix.dockerfile == 'Dockerfile.full' && 'full' || 'slim' }} --version)
           echo "$OUTPUT"
           if [[ "$OUTPUT" != *"v0.14.6"* ]]; then
             echo "❌ Expected version v0.14.6 not found in output"


### PR DESCRIPTION
Test was still valid because an unknown cli command output the header which contains the version (see https://github.com/junobuild/juno-action/actions/runs/24313852246/job/70988046968) but, to be accurate we should update the test command with the one that effectively prints the version - i.e. `juno --version`.

Few months ago I've split the version command with `juno status`.