### PR TITLE
fix: bump bundled @icp-sdk/bindgen to 0.4.0 (empty satellite_extension.did)

### DIFF
--- a/kit/setup/addons
+++ b/kit/setup/addons
@@ -2,4 +2,4 @@
 
 set -e
 
-npm i -g @icp-sdk/bindgen@0.3.0
+npm i -g @icp-sdk/bindgen@0.4.0


### PR DESCRIPTION
The image pins `@icp-sdk/bindgen@0.3.0`, which is too old to pick up `defineQuery` / `defineUpdate` exports. So `functions build` inside the action quietly produces an empty `satellite_extension.did` (`service : {}`) and ships a satellite with no custom endpoints; green CI, but every custom method 404s at runtime, and only via the action (a local CLI build against the project's own `node_modules` is fine).

Bumping the pin to `0.4.0` (the current release, and what projects on recent `@junobuild/functions` already use) fixes it.

Fixes #108.