### PR TITLE
build: bump cli v0.15.5 to fix missing custom functions in JS Rust build

### DIFF
--- a/.github/workflows/test-cli.yaml
+++ b/.github/workflows/test-cli.yaml
@@ -34,8 +34,8 @@ jobs:
         run: |
           OUTPUT=$(docker run --rm -e JUNO_TOKEN="${{ secrets.JUNO_TOKEN }}" juno-action:test-${{ matrix.dockerfile == 'Dockerfile.full' && 'full' || 'slim' }} --version)
           echo "$OUTPUT"
-          if [[ "$OUTPUT" != *"v0.15.4"* ]]; then
-            echo "❌ Expected version v0.15.4 not found in output"
+          if [[ "$OUTPUT" != *"v0.15.5"* ]]; then
+            echo "❌ Expected version v0.15.5 not found in output"
             exit 1
           fi
         shell: bash

--- a/kit/setup/tools
+++ b/kit/setup/tools
@@ -2,6 +2,6 @@
 
 set -e
 
-npm i -g @junobuild/cli@0.15.4
+npm i -g @junobuild/cli@0.15.5
 
 npm i -g pnpm@10.33.0


### PR DESCRIPTION
Relates to https://github.com/junobuild/cli/pull/515